### PR TITLE
Fixed the missing Wikitext markup for linking: [[<name of Pokémon>]]

### DIFF
--- a/pokemon_dex_entries/pokedex_entry.py
+++ b/pokemon_dex_entries/pokedex_entry.py
@@ -203,6 +203,7 @@ class PokedexEntry:
     def _build_evo_in(self):
         # Key: evoin
         # Value: provided: str - Required: str
+        # Example: [[Raichu]] or when multiple: [[Flapple]]<br />[[Appletun]]
         current_step = EvolutionLine.find_evolution_step(self.evo_line.first, self.name)
         evo_in = current_step.next
 
@@ -210,12 +211,12 @@ class PokedexEntry:
             evo_in_dex_entry = "| evoin       = "
             if type(evo_in) is list:
                 for i in range(len(evo_in)):
-                    evo_in_dex_entry += "{}".format(evo_in[i].pokemon_name)
+                    evo_in_dex_entry += "[[{}]]".format(evo_in[i].pokemon_name)
 
                     if i + 1 < len(evo_in):
                         evo_in_dex_entry += "<br />"
             else:
-                evo_in_dex_entry += "{}".format(evo_in.pokemon_name)
+                evo_in_dex_entry += "[[{}]]".format(evo_in.pokemon_name)
             evo_in_dex_entry += "\n"
             return evo_in_dex_entry
         return ""


### PR DESCRIPTION
Fixed local routing for Pokémon.

Local routing on Fandom uses `[[<local page name>]]`
Added `[[` and `]]` before and after each evolution name